### PR TITLE
Refactor drag and drop

### DIFF
--- a/client/src/app/Api.elm
+++ b/client/src/app/Api.elm
@@ -70,7 +70,7 @@ decodeListOfTasks =
 
 decodeAsanaTask : Decode.Decoder AsanaTask
 decodeAsanaTask =
-    Decode.map7 AsanaTask
+    Decode.map8 AsanaTask
         (Decode.field "id" Decode.string)
         (Decode.field "url" Decode.string)
         (Decode.field "assigneeStatus" decodeAssigneeStatus)
@@ -78,6 +78,7 @@ decodeAsanaTask =
         (Decode.field "workspace" decodeAsanaWorkspace)
         (Decode.field "name" Decode.string)
         (Decode.field "dueOn" decodeDueOn)
+        (Decode.succeed False)
 
 
 decodeAsanaProject : Decode.Decoder AsanaProject

--- a/client/src/app/State.elm
+++ b/client/src/app/State.elm
@@ -3,7 +3,6 @@ module State exposing (..)
 import Types exposing (..)
 import Navigation
 import Html5.DragDrop as DragDrop
-import Array exposing (Array)
 import Dict exposing (Dict)
 import Dom exposing (focus)
 import Task
@@ -28,7 +27,7 @@ defaultWorkspaceStorageKey =
 
 taskListStorageKey : String
 taskListStorageKey =
-    "taskList"
+    "todaySortOrder"
 
 
 titleInputId : String -> String
@@ -73,7 +72,7 @@ init flags location =
             , newAccessTokenToken = ""
             , accessTokens = []
             , tasks = Dict.empty
-            , taskList = Array.empty
+            , taskList = Nothing
             , workspaces = Dict.empty
             , defaultWorkspace = Nothing
             , buildInfo = BuildInfo flags.buildVersion flags.buildTime flags.buildTier
@@ -87,38 +86,6 @@ init flags location =
             [ LocalStorage.getItem accessTokensStorageKey, LocalStorage.getItem defaultWorkspaceStorageKey, LocalStorage.getItem taskListStorageKey ]
     in
         initialModel ! initialCommands
-
-
-moveItemInArray : Int -> Int -> Array comparable -> Array comparable
-moveItemInArray fromIndex toIndex array =
-    case Array.get fromIndex array of
-        Just item ->
-            let
-                filterItem =
-                    Array.filter (\x -> x /= item)
-
-                firstHalf =
-                    (Array.slice 0 toIndex array) |> filterItem |> Array.toList
-
-                secondHalf =
-                    (Array.slice toIndex (Array.length array)) array |> filterItem |> Array.toList
-            in
-                Array.fromList (firstHalf ++ [ item ] ++ secondHalf)
-
-        Nothing ->
-            array
-
-
-insertAfterIndex : Int -> a -> Array a -> Array a
-insertAfterIndex index item array =
-    let
-        firstHalf =
-            (Array.slice 0 (index + 1) array) |> Array.toList
-
-        secondHalf =
-            (Array.slice (index + 1) (Array.length array) array) |> Array.toList
-    in
-        Array.fromList (firstHalf ++ [ item ] ++ secondHalf)
 
 
 toggleExpandedState : AssigneeStatus -> ExpandedState -> ExpandedState
@@ -154,6 +121,92 @@ updateAssigneeStatus taskId assigneeStatus tasks =
 saveApiTokens : List AsanaAccessToken -> Cmd Msg
 saveApiTokens accessTokens =
     LocalStorage.setItem accessTokensStorageKey accessTokens Api.encodeAccessTokens
+
+
+dropInTaskList : DragTarget -> DropTarget -> Maybe TaskList -> Maybe TaskList
+dropInTaskList dragTarget dropTarget maybeTaskList =
+    case maybeTaskList of
+        Just taskList ->
+            Just (dropInTaskList_ dragTarget dropTarget taskList)
+
+        Nothing ->
+            Nothing
+
+
+updateTaskList : (List String -> List String) -> AssigneeStatus -> TaskList -> TaskList
+updateTaskList updater assigneeStatus taskList =
+    case assigneeStatus of
+        New ->
+            { taskList | new = updater taskList.new }
+
+        Today ->
+            { taskList | today = updater taskList.today }
+
+        Upcoming ->
+            { taskList | upcoming = updater taskList.upcoming }
+
+        Later ->
+            { taskList | later = updater taskList.later }
+
+
+removeIdFromTaskList : AssigneeStatus -> String -> TaskList -> TaskList
+removeIdFromTaskList assigneeStatus taskIdToRemove taskList =
+    updateTaskList (List.filter (\taskId -> taskId /= taskIdToRemove)) assigneeStatus taskList
+
+
+insertIdIntoTaskList : AssigneeStatus -> String -> (String -> List String -> List String) -> TaskList -> TaskList
+insertIdIntoTaskList assigneeStatus taskId inserter taskList =
+    updateTaskList (inserter taskId) assigneeStatus taskList
+
+
+dropInTaskList_ : DragTarget -> DropTarget -> TaskList -> TaskList
+dropInTaskList_ dragTarget dropTarget taskList =
+    let
+        ( dropAssigneeStatus, inserter ) =
+            case dropTarget of
+                Before assigneeStatus dropTaskId ->
+                    ( assigneeStatus
+                    , (\taskIdToInsert taskIds ->
+                        List.concatMap
+                            (\taskId ->
+                                if taskId == dropTaskId then
+                                    [ taskIdToInsert, taskId ]
+                                else
+                                    [ taskId ]
+                            )
+                            taskIds
+                      )
+                    )
+
+                After assigneeStatus dropTaskId ->
+                    ( assigneeStatus
+                    , (\taskIdToInsert taskIds ->
+                        List.concatMap
+                            (\taskId ->
+                                if taskId == dropTaskId then
+                                    [ taskId, taskIdToInsert ]
+                                else
+                                    [ taskId ]
+                            )
+                            taskIds
+                      )
+                    )
+
+                End assigneeStatus ->
+                    ( assigneeStatus, (\taskIdToInsert taskIds -> taskIds ++ [ taskIdToInsert ]) )
+    in
+        removeIdFromTaskList dragTarget.assigneeStatus dragTarget.targetId taskList
+            |> insertIdIntoTaskList dropAssigneeStatus dragTarget.targetId inserter
+
+
+saveTaskList : Maybe TaskList -> Cmd Msg
+saveTaskList maybeTaskList =
+    case maybeTaskList of
+        Just taskList ->
+            LocalStorage.setItem taskListStorageKey taskList Api.encodeTaskList
+
+        Nothing ->
+            Cmd.none
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -194,9 +247,9 @@ update msg model =
             else if item.key == taskListStorageKey then
                 let
                     taskList =
-                        Maybe.withDefault [] (LocalStorage.decodeToType item (Decode.list Decode.string))
+                        LocalStorage.decodeToType item Api.decodeTaskList
                 in
-                    { model | taskList = Array.fromList taskList } ! []
+                    { model | taskList = taskList } ! []
             else
                 model ! []
 
@@ -235,21 +288,42 @@ update msg model =
 
         LoadTasks (Ok newTasks) ->
             let
-                currentlySortedTaskIds =
-                    Set.fromList (Array.toList model.taskList)
+                new =
+                    Dict.values tasks
+                        |> List.filter (\task -> task.assigneeStatus == New)
+                        |> List.map .id
 
-                unsortedIds =
-                    List.filterMap
-                        (\task ->
-                            if not (Set.member task.id currentlySortedTaskIds) then
-                                Just task.id
-                            else
-                                Nothing
-                        )
-                        newTasks
+                currentTodayTasks =
+                    Maybe.withDefault [] (Maybe.map .today model.taskList)
+
+                currentTodayTasksLookUp =
+                    Set.fromList currentTodayTasks
+
+                newTodayTasks =
+                    Dict.values tasks
+                        |> List.filter (\task -> task.assigneeStatus == Today && not (Set.member task.id currentTodayTasksLookUp))
+                        |> List.map .id
+
+                today =
+                    newTodayTasks ++ currentTodayTasks
+
+                sortByDate =
+                    List.sortBy (.dueOn >> Maybe.map Date.toTime >> Maybe.withDefault 0)
+
+                upcoming =
+                    Dict.values tasks
+                        |> List.filter (\task -> task.assigneeStatus == Upcoming)
+                        |> sortByDate
+                        |> List.map .id
+
+                later =
+                    Dict.values tasks
+                        |> List.filter (\task -> task.assigneeStatus == Later)
+                        |> sortByDate
+                        |> List.map .id
 
                 taskList =
-                    (unsortedIds ++ (Array.toList model.taskList))
+                    TaskList new today upcoming later
 
                 tasks =
                     Dict.fromList (List.map (\task -> ( task.id, task )) newTasks)
@@ -260,7 +334,13 @@ update msg model =
                 ( datePickers, datePickerFx ) =
                     initDatePickers (Dict.values tasks)
             in
-                { model | taskList = Array.fromList taskList, tasks = tasks, datePickers = datePickers, workspaces = workspaces } ! datePickerFx
+                { model
+                    | taskList = Just taskList
+                    , tasks = tasks
+                    , datePickers = datePickers
+                    , workspaces = workspaces
+                }
+                    ! datePickerFx
 
         SetDefaultWorkspace workspaceId ->
             { model | defaultWorkspace = Just workspaceId } ! [ LocalStorage.setItem defaultWorkspaceStorageKey workspaceId Encode.string ]
@@ -271,7 +351,8 @@ update msg model =
         CompleteTask completedTaskId ->
             case Dict.get completedTaskId model.tasks of
                 Just task ->
-                    { model | taskList = Array.filter (\taskId -> taskId /= completedTaskId) model.taskList } ! [ Api.updateTask model.apiHost model.accessTokens task Complete ]
+                    -- TODO: Complete task
+                    model ! [ Api.updateTask model.apiHost model.accessTokens task Complete ]
 
                 Nothing ->
                     model ! []
@@ -303,12 +384,12 @@ update msg model =
                 Nothing ->
                     model ! []
 
-        AddNewTask ( assigneeStatus, _, index ) ->
+        AddNewTask assigneeStatus taskId ->
             case (Maybe.andThen (\workspaceId -> Dict.get workspaceId model.workspaces) model.defaultWorkspace) of
                 Just workspace ->
                     let
                         localId =
-                            "local-" ++ toString (Array.length model.taskList)
+                            "local-" ++ toString (Dict.size model.tasks)
 
                         task =
                             AsanaTask localId "" assigneeStatus [] workspace "" Nothing
@@ -316,8 +397,9 @@ update msg model =
                         ( datePicker, datePickerFx ) =
                             DatePicker.init defaultSettings
 
+                        -- TODO
                         taskList =
-                            insertAfterIndex index task.id model.taskList
+                            dropInTaskList (DragTarget task.assigneeStatus task.id) (After assigneeStatus taskId) model.taskList
                     in
                         { model
                             | tasks = Dict.insert task.id task model.tasks
@@ -367,16 +449,18 @@ update msg model =
                 tasks =
                     Dict.insert task.id task model.tasks
 
+                -- TODO: Replace localTaskId in task list
                 taskList =
-                    Array.map
-                        (\taskId ->
-                            if taskId == localTaskId then
-                                task.id
-                            else
-                                taskId
-                        )
-                        model.taskList
+                    model.taskList
 
+                -- List.map
+                --     (\taskId ->
+                --         if taskId == localTaskId then
+                --             task.id
+                --         else
+                --             taskId
+                --     )
+                --     model.taskList
                 datePickers =
                     case Dict.get localTaskId model.datePickers of
                         Just datePicker ->
@@ -385,41 +469,50 @@ update msg model =
                         Nothing ->
                             model.datePickers
             in
-                { model | tasks = tasks, taskList = taskList, datePickers = datePickers } ! []
+                { model
+                    | tasks = tasks
+                    , taskList = taskList
+                    , datePickers = datePickers
+                }
+                    ! []
 
         TaskUpdated result ->
             model ! []
 
-        DragDropMsg msg_ ->
+        DragDropMsg dragDropMessage ->
             let
-                ( model_, result ) =
-                    DragDrop.update msg_ model.dragDrop
+                ( dragDrop, result ) =
+                    DragDrop.update dragDropMessage model.dragDrop
 
                 ( taskList, tasks, commands ) =
                     case result of
-                        Just ( ( dragAssigneeStatus, dragTaskId, dragIndex ), ( dropAssigneeStatus, _, dropIndex ) ) ->
-                            case Dict.get dragTaskId model.tasks of
-                                Just task ->
-                                    ( moveItemInArray dragIndex dropIndex model.taskList
-                                    , updateAssigneeStatus dragTaskId dropAssigneeStatus model.tasks
-                                    , [ Api.updateTask model.apiHost model.accessTokens task (UpdateAssigneeStatus dropAssigneeStatus)
-                                      ]
-                                    )
+                        Just ( dragTarget, dropTarget ) ->
+                            let
+                                newAssigneeStatus =
+                                    assigneeStatusFromDropTarget dropTarget
+                            in
+                                case Dict.get dragTarget.targetId model.tasks of
+                                    Just task ->
+                                        ( dropInTaskList dragTarget dropTarget model.taskList
+                                        , updateAssigneeStatus dragTarget.targetId newAssigneeStatus model.tasks
+                                        , [ Api.updateTask model.apiHost model.accessTokens task (UpdateAssigneeStatus newAssigneeStatus)
+                                          ]
+                                        )
 
-                                Nothing ->
-                                    ( model.taskList, model.tasks, [] )
+                                    Nothing ->
+                                        ( model.taskList, model.tasks, [] )
 
                         Nothing ->
                             ( model.taskList, model.tasks, [] )
 
                 updatedModel =
                     { model
-                        | dragDrop = model_
+                        | dragDrop = dragDrop
                         , taskList = taskList
                         , tasks = tasks
                     }
             in
-                updatedModel ! (commands ++ [ LocalStorage.setItem taskListStorageKey (Array.toList updatedModel.taskList) (List.map Encode.string >> Encode.list) ])
+                updatedModel ! (commands ++ [ saveTaskList updatedModel.taskList ])
 
         ToggleAssigneeStatusOverlay taskId ->
             { model

--- a/client/src/app/State.elm
+++ b/client/src/app/State.elm
@@ -397,7 +397,6 @@ update msg model =
                         ( datePicker, datePickerFx ) =
                             DatePicker.init defaultSettings
 
-                        -- TODO
                         taskList =
                             dropInTaskList (DragTarget task.assigneeStatus task.id) (After assigneeStatus taskId) model.taskList
                     in
@@ -449,18 +448,21 @@ update msg model =
                 tasks =
                     Dict.insert task.id task model.tasks
 
-                -- TODO: Replace localTaskId in task list
                 taskList =
-                    model.taskList
+                    Maybe.map
+                        (updateTaskList
+                            (List.map
+                                (\taskId ->
+                                    if taskId == localTaskId then
+                                        task.id
+                                    else
+                                        taskId
+                                )
+                            )
+                            task.assigneeStatus
+                        )
+                        model.taskList
 
-                -- List.map
-                --     (\taskId ->
-                --         if taskId == localTaskId then
-                --             task.id
-                --         else
-                --             taskId
-                --     )
-                --     model.taskList
                 datePickers =
                     case Dict.get localTaskId model.datePickers of
                         Just datePicker ->
@@ -468,13 +470,15 @@ update msg model =
 
                         Nothing ->
                             model.datePickers
+
+                updatedModel =
+                    { model
+                        | tasks = tasks
+                        , taskList = taskList
+                        , datePickers = datePickers
+                    }
             in
-                { model
-                    | tasks = tasks
-                    , taskList = taskList
-                    , datePickers = datePickers
-                }
-                    ! []
+                updatedModel ! [ saveTaskList updatedModel.taskList ]
 
         TaskUpdated result ->
             model ! []

--- a/client/src/app/State.elm
+++ b/client/src/app/State.elm
@@ -27,7 +27,7 @@ defaultWorkspaceStorageKey =
 
 taskListStorageKey : String
 taskListStorageKey =
-    "todaySortOrder"
+    "taskList"
 
 
 titleInputId : String -> String

--- a/client/src/app/State.elm
+++ b/client/src/app/State.elm
@@ -351,8 +351,11 @@ update msg model =
         CompleteTask completedTaskId ->
             case Dict.get completedTaskId model.tasks of
                 Just task ->
-                    -- TODO: Complete task
-                    model ! [ Api.updateTask model.apiHost model.accessTokens task Complete ]
+                    let
+                        updatedTask =
+                            { task | completed = True }
+                    in
+                        { model | tasks = Dict.insert updatedTask.id updatedTask model.tasks } ! [ Api.updateTask model.apiHost model.accessTokens task Complete ]
 
                 Nothing ->
                     model ! []
@@ -392,7 +395,7 @@ update msg model =
                             "local-" ++ toString (Dict.size model.tasks)
 
                         task =
-                            AsanaTask localId "" assigneeStatus [] workspace "" Nothing
+                            AsanaTask localId "" assigneeStatus [] workspace "" Nothing False
 
                         ( datePicker, datePickerFx ) =
                             DatePicker.init defaultSettings

--- a/client/src/app/Types.elm
+++ b/client/src/app/Types.elm
@@ -36,6 +36,7 @@ type alias AsanaTask =
     , workspace : AsanaWorkspace
     , name : String
     , dueOn : Maybe Date
+    , completed : Bool
     }
 
 

--- a/client/src/app/View.elm
+++ b/client/src/app/View.elm
@@ -177,7 +177,11 @@ taskListSegmentView config today expandedAssigneeStatusOverlay tasks currentDrop
 
         taskViews =
             if expanded then
-                (List.map (\( task, datePicker ) -> taskView today (hasExpandedAssigneeStatusOverlay task) datePicker currentDropTarget task) tasks)
+                List.filter (\( task, _ ) -> not task.completed) tasks
+                    |> List.map
+                        (\( task, datePicker ) ->
+                            taskView today (hasExpandedAssigneeStatusOverlay task) datePicker currentDropTarget task
+                        )
             else
                 []
 
@@ -289,10 +293,6 @@ checkMark =
     Svg.svg [ Svg.Attributes.viewBox "0 0 32 32" ]
         [ Svg.polygon [ Svg.Attributes.points "27.672,4.786 10.901,21.557 4.328,14.984 1.5,17.812 10.901,27.214 30.5,7.615 " ] []
         ]
-
-
-
--- TODO: Possibly wrong
 
 
 taskTitleView : String -> AssigneeStatus -> String -> Html Msg

--- a/client/src/app/View.elm
+++ b/client/src/app/View.elm
@@ -15,23 +15,22 @@ import Html.Events exposing (onClick, onInput, onBlur)
 import Dict exposing (Dict)
 import Types exposing (..)
 import Html5.DragDrop as DragDrop
-import Array exposing (Array)
 import Json.Decode as Json
 import State exposing (titleInputId)
 
 
-expandTasks : Dict String AsanaTask -> Dict String DatePicker.DatePicker -> List String -> List ( Int, AssigneeStatus, AsanaTask, DatePicker.DatePicker )
+expandTasks : Dict String AsanaTask -> Dict String DatePicker.DatePicker -> List String -> List ( AsanaTask, DatePicker.DatePicker )
 expandTasks allTasks datePickers taskList =
     List.filterMap
-        (\( index, taskId ) ->
+        (\taskId ->
             case ( Dict.get taskId allTasks, Dict.get taskId datePickers ) of
                 ( Just task, Just datePicker ) ->
-                    Just ( index, task.assigneeStatus, task, datePicker )
+                    Just ( task, datePicker )
 
                 _ ->
                     Nothing
         )
-        (List.indexedMap (,) taskList)
+        taskList
 
 
 rootView : Model -> Html Msg
@@ -104,32 +103,11 @@ accessTokenView accessToken =
 
 
 tasksView : Model -> Html Msg
-tasksView { today, accessTokenFormExpanded, expandedAssigneeStatusOverlay, accessTokens, taskList, tasks, workspaces, defaultWorkspace, dragDrop, buildInfo, expanded, datePickers } =
-    let
-        allTasksWithIndexAndCategory =
-            expandTasks tasks datePickers (Array.toList taskList)
-
-        dropId =
-            DragDrop.getDropId dragDrop
-
-        preferredOrder =
-            List.indexedMap (\index taskId -> ( taskId, index )) (Array.toList taskList) |> Dict.fromList
-
-        sortByPreferred =
-            List.sortBy (\( _, task, _ ) -> Maybe.withDefault 0 (Dict.get task.id preferredOrder))
-
-        sortByDate =
-            List.sortBy (\( index, task, _ ) -> ( Maybe.withDefault 0 (Maybe.map Date.toTime task.dueOn), index ))
-    in
-        div []
-            [ div [ class "workspaces" ] (List.map (workspaceView defaultWorkspace) (Dict.values workspaces))
-            , div []
-                [ taskListView today expandedAssigneeStatusOverlay True New "New" allTasksWithIndexAndCategory dropId expanded.new identity
-                , taskListView today expandedAssigneeStatusOverlay False Today "Today" allTasksWithIndexAndCategory dropId expanded.today sortByPreferred
-                , taskListView today expandedAssigneeStatusOverlay False Upcoming "Upcoming" allTasksWithIndexAndCategory dropId expanded.upcoming sortByDate
-                , taskListView today expandedAssigneeStatusOverlay False Later "Later" allTasksWithIndexAndCategory dropId expanded.later sortByDate
-                ]
-            ]
+tasksView model =
+    div []
+        [ div [ class "workspaces" ] (List.map (workspaceView model.defaultWorkspace) (Dict.values model.workspaces))
+        , taskListView model
+        ]
 
 
 workspaceView : Maybe String -> AsanaWorkspace -> Html Msg
@@ -147,48 +125,91 @@ workspaceView maybeDefaultWorkspace workspace =
         [ text workspace.name ]
 
 
-taskListView : Date -> Maybe String -> Bool -> AssigneeStatus -> String -> List ( Int, AssigneeStatus, AsanaTask, DatePicker.DatePicker ) -> Maybe TaskListIndex -> Bool -> (List ( Int, AsanaTask, DatePicker.DatePicker ) -> List ( Int, AsanaTask, DatePicker.DatePicker )) -> Html Msg
-taskListView today expandedAssigneeStatusOverlay hideOnEmpty assigneeStatus title allTasks maybeDropId expanded sorter =
-    let
-        tasksWithThisStatus =
-            List.filter (\( _, taskAssigneeStatus, _, _ ) -> taskAssigneeStatus == assigneeStatus) allTasks
-                |> List.map (\( index, assigneeStatus, task, datePicker ) -> ( index, task, datePicker ))
-                |> sorter
+taskListView : Model -> Html Msg
+taskListView { today, accessTokenFormExpanded, expandedAssigneeStatusOverlay, taskList, tasks, dragDrop, expanded, datePickers } =
+    case taskList of
+        Just taskList ->
+            let
+                currentDropTarget =
+                    DragDrop.getDropId dragDrop
 
+                newTasks =
+                    expandTasks tasks datePickers taskList.new
+
+                todayTasks =
+                    expandTasks tasks datePickers taskList.today
+
+                upcomingTasks =
+                    expandTasks tasks datePickers taskList.upcoming
+
+                laterTasks =
+                    expandTasks tasks datePickers taskList.later
+            in
+                div []
+                    [ taskListSegmentView ({ assigneeStatus = New, title = "New", hideOnEmpty = True }) today expandedAssigneeStatusOverlay newTasks currentDropTarget expanded.new
+                    , taskListSegmentView ({ assigneeStatus = Today, title = "Today", hideOnEmpty = False }) today expandedAssigneeStatusOverlay todayTasks currentDropTarget expanded.today
+                    , taskListSegmentView ({ assigneeStatus = Upcoming, title = "Upcoming", hideOnEmpty = False }) today expandedAssigneeStatusOverlay upcomingTasks currentDropTarget expanded.upcoming
+                    , taskListSegmentView ({ assigneeStatus = Later, title = "Later", hideOnEmpty = False }) today expandedAssigneeStatusOverlay laterTasks currentDropTarget expanded.later
+                    ]
+
+        Nothing ->
+            div [] [ text "Loading..." ]
+
+
+filterTasksByStatus : AssigneeStatus -> List ( Int, AssigneeStatus, AsanaTask, DatePicker.DatePicker ) -> List ( Int, AsanaTask, DatePicker.DatePicker )
+filterTasksByStatus assigneeStatus tasks =
+    List.filter (\( _, taskAssigneeStatus, _, _ ) -> taskAssigneeStatus == assigneeStatus) tasks
+        |> List.map (\( index, _, task, datePicker ) -> ( index, task, datePicker ))
+
+
+type alias TaskListSegmentConfig =
+    { assigneeStatus : AssigneeStatus
+    , title : String
+    , hideOnEmpty : Bool
+    }
+
+
+taskListSegmentView : TaskListSegmentConfig -> Date -> Maybe String -> List ( AsanaTask, DatePicker.DatePicker ) -> Maybe DropTarget -> Bool -> Html Msg
+taskListSegmentView config today expandedAssigneeStatusOverlay tasks currentDropTarget expanded =
+    let
         hasExpandedAssigneeStatusOverlay =
             \task -> Just task.id == expandedAssigneeStatusOverlay
 
         taskViews =
-            (List.map (\( index, task, datePicker ) -> taskView today (hasExpandedAssigneeStatusOverlay task) datePicker maybeDropId ( assigneeStatus, task.id, index ) task) tasksWithThisStatus)
+            if expanded then
+                (List.map (\( task, datePicker ) -> taskView today (hasExpandedAssigneeStatusOverlay task) datePicker currentDropTarget task) tasks)
+            else
+                []
 
         dropView =
-            fakeDropView maybeDropId ( assigneeStatus, "", ((List.length tasksWithThisStatus) + 1) )
+            fakeDropView currentDropTarget (End config.assigneeStatus)
     in
-        if hideOnEmpty && List.length tasksWithThisStatus == 0 then
+        if config.hideOnEmpty && List.length tasks == 0 then
             text ""
         else
             div []
-                [ h2
-                    [ class "tasksHeader", onClick (ToggleExpanded assigneeStatus) ]
-                    [ div
-                        [ class
-                            ("tasksHeaderTriangleIcon"
-                                ++ if not expanded then
-                                    " closed"
-                                   else
-                                    ""
-                            )
-                        ]
-                        [ triangle ]
-                    , text title
-                    ]
+                [ taskListHeaderView config.assigneeStatus config.title expanded
                 , ul [ class "tasks" ]
-                    (if expanded then
-                        taskViews ++ [ dropView ]
-                     else
-                        [ dropView ]
-                    )
+                    (taskViews ++ [ dropView ])
                 ]
+
+
+taskListHeaderView : AssigneeStatus -> String -> Bool -> Html Msg
+taskListHeaderView assigneeStatus title expanded =
+    h2
+        [ class "tasksHeader", onClick (ToggleExpanded assigneeStatus) ]
+        [ div
+            [ class
+                ("tasksHeaderTriangleIcon"
+                    ++ if not expanded then
+                        " closed"
+                       else
+                        ""
+                )
+            ]
+            [ triangle ]
+        , text title
+        ]
 
 
 triangle : Html Msg
@@ -198,12 +219,12 @@ triangle =
         ]
 
 
-classNameIfOnTop : Maybe TaskListIndex -> TaskListIndex -> String
-classNameIfOnTop maybeDropId ( category, _, index ) =
-    case maybeDropId of
-        Just ( dropCategory, _, dropIndex ) ->
-            if dropCategory == category && dropIndex == index then
-                " onTop"
+classNameIfOnTop : Maybe DropTarget -> DropTarget -> String
+classNameIfOnTop maybeCurrentDropTarget dropTarget =
+    case maybeCurrentDropTarget of
+        Just currentDropTarget ->
+            if equalDropTarget currentDropTarget dropTarget then
+                "onTop"
             else
                 ""
 
@@ -211,17 +232,20 @@ classNameIfOnTop maybeDropId ( category, _, index ) =
             ""
 
 
-taskView : Date -> Bool -> DatePicker.DatePicker -> Maybe TaskListIndex -> TaskListIndex -> AsanaTask -> Html Msg
-taskView today assigneeStatusViewIsExpanded datePicker maybeDropId index task =
+taskView : Date -> Bool -> DatePicker.DatePicker -> Maybe DropTarget -> AsanaTask -> Html Msg
+taskView today assigneeStatusViewIsExpanded datePicker currentDropTarget task =
     let
+        dropTarget =
+            Before task.assigneeStatus task.id
+
         classNames =
-            "task" ++ (classNameIfOnTop maybeDropId index)
+            "task " ++ (classNameIfOnTop currentDropTarget dropTarget)
 
         isHeading =
             String.endsWith ":" task.name
     in
         li
-            ([ class classNames ] ++ DragDrop.draggable DragDropMsg index ++ DragDrop.droppable DragDropMsg index)
+            ([ class classNames ] ++ DragDrop.draggable DragDropMsg (DragTarget task.assigneeStatus task.id) ++ DragDrop.droppable DragDropMsg dropTarget)
             (if isHeading then
                 [ div [ class "taskDragHandle" ] [ dragHandle ]
                 , div [ class "taskTitleAsHeader" ] [ h3 [] [ text task.name ] ]
@@ -232,7 +256,7 @@ taskView today assigneeStatusViewIsExpanded datePicker maybeDropId index task =
                 , div [ class "taskWorkspaceAndTitle" ]
                     [ div [ class "taskWorkspace" ]
                         [ text task.workspace.name ]
-                    , taskTitleView index task.id task.name
+                    , taskTitleView task.id task.assigneeStatus task.name
                     ]
                 ]
                     ++ (if task.url /= "" then
@@ -267,9 +291,13 @@ checkMark =
         ]
 
 
-taskTitleView : TaskListIndex -> String -> String -> Html Msg
-taskTitleView index taskId title =
-    input [ class "taskTitle", id (titleInputId taskId), onInput (EditTaskName taskId), onBlur (StopEditTaskName taskId), onEnterPress (AddNewTask index), value title ] []
+
+-- TODO: Possibly wrong
+
+
+taskTitleView : String -> AssigneeStatus -> String -> Html Msg
+taskTitleView taskId assigneeStatus title =
+    input [ class "taskTitle", id (titleInputId taskId), onInput (EditTaskName taskId), onBlur (StopEditTaskName taskId), onEnterPress (AddNewTask assigneeStatus taskId), value title ] []
 
 
 removeTimePart : Date -> Date
@@ -358,14 +386,14 @@ assigneeStatusView expanded task =
         ]
 
 
-fakeDropView : Maybe TaskListIndex -> TaskListIndex -> Html Msg
-fakeDropView maybeDropId index =
+fakeDropView : Maybe DropTarget -> DropTarget -> Html Msg
+fakeDropView currentDropTarget dropTarget =
     let
         classNames =
-            "fakeDropView" ++ (classNameIfOnTop maybeDropId index)
+            "fakeDropView " ++ (classNameIfOnTop currentDropTarget dropTarget)
     in
         li
-            ([ class classNames ] ++ DragDrop.droppable DragDropMsg index)
+            ([ class classNames ] ++ DragDrop.droppable DragDropMsg dropTarget)
             []
 
 


### PR DESCRIPTION
Stop storing tasklist as a single list and rather store it as prefiltered by assignee status. Makes it easier to understand the drag and drop messages. 